### PR TITLE
Ensure e2e tests use newly generated app version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -43,7 +43,7 @@ pipeline:
 
   # check a new change can be opened
   e2e_test_open:
-    image: '${DOCKER_REPO}/${DOCKER_PATH}/${NAME}'
+    image: '${DOCKER_REPO}/${DOCKER_PATH}/${NAME}:${MAJOR}.${MINOR}.${PATCH}-${DRONE_COMMIT:0:10}'
     secrets: [ service_now_username, service_now_password ]
     description: 'End-to-end test for the ServiceNow CD utility. Build #${DRONE_BUILD_NUMBER}'
     when:
@@ -52,7 +52,7 @@ pipeline:
 
   # check the change can be closed
   e2e_test_close:
-    image: '${DOCKER_REPO}/${DOCKER_PATH}/${NAME}'
+    image: '${DOCKER_REPO}/${DOCKER_PATH}/${NAME}:${MAJOR}.${MINOR}.${PATCH}-${DRONE_COMMIT:0:10}'
     secrets: [ service_now_username, service_now_password ]
     comments: 'Successfully tested build #${DRONE_BUILD_NUMBER}'
     deployment_outcome: success


### PR DESCRIPTION
...which should also avoid dodgy drone caching nonsense.