### PR TITLE
Issue25 - Cleanse text contents sent to ServiceNow

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ matrix:
   MINOR:
     - 0
   PATCH:
-    - 4
+    - 5
   DOCKER_USERNAME:
     - ukhomeofficedigital+snowtify
   DOCKER_REPO:

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -25,7 +25,7 @@ rules:
   # disallow use of constant expressions in conditions
   no-constant-condition: 2
   # disallow control characters in regular expressions
-  no-control-regex: 2
+  no-control-regex: 1
   # disallow use of debugger
   no-debugger: 2
   # disallow duplicate keys when creating object literals

--- a/config.js
+++ b/config.js
@@ -15,6 +15,7 @@ const loadFromFile = file => { // eslint-disable-line consistent-return
     }
   }
 };
+const stripControl = text => text && text.replace(/\x1b\[\d+m/g, '').replace(/[\0-\x08\x11-\x1f]/g, '');
 
 logger.debug('Process environment variables');
 const pe                = global.injected && global.injected.env || process.env;
@@ -55,7 +56,7 @@ const messageTemplates  = {
     payload:               {
       title:       title,
       endTime:     endTime,
-      description: description,
+      description: stripControl(description),
       supplierRef: externalID,
     }
   },
@@ -64,13 +65,13 @@ const messageTemplates  = {
     'internal_identifier': internalID,
     payload:               {
       success:  deploymentOutcome ? 'true' : 'false',
-      comments: comments
+      comments: stripControl(comments)
     }
   }
 };
 
 if (testing) {
-  messageTemplates.openChange.payload.testing = testing;
+  messageTemplates.openChange.payload.testing = stripControl(testing);
 }
 
 const config = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "snowtify",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowtify",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A `drone.io` plugin to connect the ServiceNow API to a CD pipeline.",
   "main": "index.js",
   "bin": "./index.js",

--- a/test/config.js
+++ b/test/config.js
@@ -36,9 +36,9 @@ describe('Config module', () => {
         files[dir][content]   = contents;
         files[dir][noContent] = '';
         mfs(files);
+        this.loadFromFile = prop(config, 'loadFromFile');
       });
       beforeEach(() => {
-        this.loadFromFile = prop(config, 'loadFromFile');
         this.readFileSync = sinon.spy(prop(config, 'fs'), 'readFileSync');
       });
 
@@ -67,6 +67,21 @@ describe('Config module', () => {
       after(() => {
         mfs.restore();
       });
+    });
+
+    describe('#stripControl', function () {
+      before('get fixture text', () => {
+        const load = prop(config, 'loadFromFile');
+        this.text = load('./test/fixtures/test-output.txt');
+        this.clean = load('./test/fixtures/clean-output.txt');
+        this.stripControl = prop(config, 'stripControl');
+      });
+      it('should remove the unwated (control) characters from the text input', () =>
+        expect(this.stripControl(this.text))
+          .be.a('string')
+          .and.have.lengthOf.below(this.text.length)
+          .and.to.match(/^[^\0-\x08\x11-\x1f]+$/g)
+          .and.to.equal(this.clean));
     });
   });
 

--- a/test/fixtures/clean-output.txt
+++ b/test/fixtures/clean-output.txt
@@ -1,0 +1,26 @@
+
+* E2E test logs for promotion to uat *
+
+
+> lev-web@0.1.0 test:browser /app
+> npm run $([ -n "${SMOKE_TEST}" ] && echo smoke || echo chimp)
+
+
+> lev-web@0.1.0 smoke /app
+> chimp --mocha --browser=phantomjs --path=./test/smoke/
+
+
+Master Chimp and become a testing Ninja! Check out our course: http://bit.ly/2btQaFu
+
+
+[chimp] Running...
+
+
+  Smoke Tests
+    Trying to see a non-existent record
+      ✓ presents me with the login prompt
+      ✓ allows me to login to LEV
+      ✓ presents me with the NOT FOUND error page
+
+
+  3 passing (2s)

--- a/test/fixtures/test-output.txt
+++ b/test/fixtures/test-output.txt
@@ -1,0 +1,26 @@
+
+* E2E test logs for promotion to uat *
+
+
+> lev-web@0.1.0 test:browser /app
+> npm run $([ -n "${SMOKE_TEST}" ] && echo smoke || echo chimp)
+
+
+> lev-web@0.1.0 smoke /app
+> chimp --mocha --browser=phantomjs --path=./test/smoke/
+
+[32m
+Master Chimp and become a testing Ninja! Check out our course: [39m[4m[34mhttp://bit.ly/2btQaFu
+[39m[24m
+[33m
+[chimp] Running...[39m
+
+[0m[0m
+[0m  Smoke Tests[0m
+[0m    Trying to see a non-existent record[0m
+    [32m  ✓[0m[90m presents me with the login prompt[0m
+    [32m  ✓[0m[90m allows me to login to LEV[0m
+    [32m  ✓[0m[90m presents me with the NOT FOUND error page[0m
+
+
+[92m [0m[32m 3 passing[0m[90m (2s)[0m


### PR DESCRIPTION
Make sure that the description and testing contents sent as part of a new change, and the comments sent as part of an update notification, are stripped of colour coding and control characters.